### PR TITLE
Changing LOC to LOCCommon

### DIFF
--- a/source/Services/IndiegalaAccountClient.cs
+++ b/source/Services/IndiegalaAccountClient.cs
@@ -223,7 +223,7 @@ namespace IndiegalaLibrary.Services
                     logger.Warn($"SearchGameStore() - No cookies");
                     PlayniteApi.Notifications.Add(new NotificationMessage(
                         "Indiegala-Error-UserCollections",
-                        "Indiegala" + System.Environment.NewLine + PlayniteApi.Resources.GetString("LOCLoginRequired"),
+                        "Indiegala" + System.Environment.NewLine + PlayniteApi.Resources.GetString("LOCCommonLoginRequired"),
                         NotificationType.Error,
                         () =>
                         {
@@ -291,7 +291,7 @@ namespace IndiegalaLibrary.Services
                     logger.Warn($"SearchGameShowcase() - No cookies");
                     PlayniteApi.Notifications.Add(new NotificationMessage(
                         "Indiegala-Error-UserCollections",
-                        "Indiegala" + System.Environment.NewLine + PlayniteApi.Resources.GetString("LOCLoginRequired"),
+                        "Indiegala" + System.Environment.NewLine + PlayniteApi.Resources.GetString("LOCCommonLoginRequired"),
                         NotificationType.Error,
                         () =>
                         {
@@ -434,7 +434,7 @@ namespace IndiegalaLibrary.Services
                         logger.Warn($"GetUserCollections() - No cookies");
                         API.Instance.Notifications.Add(new NotificationMessage(
                             "Indiegala-Error-UserCollections",
-                            "Indiegala" + System.Environment.NewLine + API.Instance.Resources.GetString("LOCLoginRequired"),
+                            "Indiegala" + System.Environment.NewLine + API.Instance.Resources.GetString("LOCCommonLoginRequired"),
                             NotificationType.Error,
                             () =>
                             {
@@ -465,7 +465,7 @@ namespace IndiegalaLibrary.Services
                 Common.LogError(ex, false);
                 API.Instance.Notifications.Add(new NotificationMessage(
                     "Indiegala-Error-UserCollections",
-                    "Indiegala" + System.Environment.NewLine + API.Instance.Resources.GetString("LOCLoginRequired"),
+                    "Indiegala" + System.Environment.NewLine + API.Instance.Resources.GetString("LOCCommonLoginRequired"),
                     NotificationType.Error,
                     () =>
                     {
@@ -541,7 +541,7 @@ namespace IndiegalaLibrary.Services
                 logger.Warn($"GetOwnedClient() - No cookies");
                 PlayniteApi.Notifications.Add(new NotificationMessage(
                     "Indiegala-Error-UserCollections",
-                    "Indiegala" + System.Environment.NewLine + PlayniteApi.Resources.GetString("LOCLoginRequired"),
+                    "Indiegala" + System.Environment.NewLine + PlayniteApi.Resources.GetString("LOCCommonLoginRequired"),
                     NotificationType.Error,
                     () =>
                     {
@@ -754,7 +754,7 @@ namespace IndiegalaLibrary.Services
                                     logger.Warn($"GetOwnedGamesBundleStore() - No cookies");
                                     Plugin.PlayniteApi.Notifications.Add(new NotificationMessage(
                                         "Indiegala-Error-UserCollections",
-                                        "Indiegala" + System.Environment.NewLine + Plugin.PlayniteApi.Resources.GetString("LOCLoginRequired"),
+                                        "Indiegala" + System.Environment.NewLine + Plugin.PlayniteApi.Resources.GetString("LOCCommonLoginRequired"),
                                         NotificationType.Error,
                                         () =>
                                         {

--- a/source/Views/IndiegalaLibrarySettingsView.xaml.cs
+++ b/source/Views/IndiegalaLibrarySettingsView.xaml.cs
@@ -72,7 +72,7 @@ namespace IndiegalaLibrary.Views
                         {
                             if (antecedent.Result)
                             {
-                                PART_LabelAuthWithClient.Content = resources.GetString("LOCLoggedIn");
+                                PART_LabelAuthWithClient.Content = resources.GetString("LOCCommonLoggedIn");
                             }
                             else
                             {
@@ -82,7 +82,7 @@ namespace IndiegalaLibrary.Views
                                 }
                                 else
                                 {
-                                    PART_LabelAuthWithClient.Content = resources.GetString("LOCNotLoggedIn");
+                                    PART_LabelAuthWithClient.Content = resources.GetString("LOCCommonNotLoggedIn");
                                 }
                             }
                         }));
@@ -94,7 +94,7 @@ namespace IndiegalaLibrary.Views
         private void Button_ClickWithClient(object sender, RoutedEventArgs e)
         {
             IndiegalaApi.ResetClientCookies();
-            PART_LabelAuthWithClient.Content = resources.GetString("LOCLoginChecking");
+            PART_LabelAuthWithClient.Content = resources.GetString("LOCCommonLoginChecking");
 
             try
             {
@@ -155,7 +155,7 @@ namespace IndiegalaLibrary.Views
         {
             PART_Unlock.Visibility = Visibility.Collapsed;
             IndiegalaApi.ResetClientCookies();
-            PART_LabelAuthWithoutClient.Content = resources.GetString("LOCLoginChecking");
+            PART_LabelAuthWithoutClient.Content = resources.GetString("LOCCommonLoginChecking");
 
             var task = Task.Run(() => IndiegalaApi.GetIsUserLoggedInWithoutClient())
                 .ContinueWith(antecedent =>
@@ -172,11 +172,11 @@ namespace IndiegalaLibrary.Views
                                     break;
 
                                 case ConnectionState.Unlogged:
-                                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCNotLoggedIn");
+                                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCCommonNotLoggedIn");
                                     break;
 
                                 case ConnectionState.Logged:
-                                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCLoggedIn");
+                                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCCommonLoggedIn");
                                     break;
                             }
                         }));
@@ -188,7 +188,7 @@ namespace IndiegalaLibrary.Views
         private void Button_ClickWithoutClient(object sender, RoutedEventArgs e)
         {
             IndiegalaApi.ResetClientCookies();
-            PART_LabelAuthWithoutClient.Content = resources.GetString("LOCLoginChecking");
+            PART_LabelAuthWithoutClient.Content = resources.GetString("LOCCommonLoginChecking");
 
             try
             {
@@ -196,11 +196,11 @@ namespace IndiegalaLibrary.Views
 
                 if (IndiegalaApi.isConnected)
                 {
-                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCLoggedIn");
+                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCCommonLoggedIn");
                 }
                 else
                 {
-                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCNotLoggedIn");
+                    PART_LabelAuthWithoutClient.Content = resources.GetString("LOCCommonNotLoggedIn");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Translation files refer to LOCCommonNotLoggedin, LOCCommonLoggedIn, and LOCCommonLoginChecking, but code refers to those without 'Common,' breaking the localizations in the extension settings. I changed them to add Common.